### PR TITLE
Fix gulp plugin when used with file watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "gulp-util": "^3.0.1",
-    "through2": "^0.6.3"
+    "plexer": "^2.0.0"
   },
   "homepage": "https://github.com/GoodRx/gulp-pypugjs",
   "repository": {


### PR DESCRIPTION
### Description
This plugin works fine for one time builds, but if the pipe fails when used multiple times in succession (file watching in particular). The changes here use `Stream` instead of `through2` as I had more success with that (follows more modern guidelines for writing plugins).